### PR TITLE
Base TLS cert and key filenames on hostname. Fixes #38.

### DIFF
--- a/xenon/compat.py
+++ b/xenon/compat.py
@@ -9,8 +9,6 @@ import os
 import sys
 import signal
 
-from xdg import BaseDirectory
-
 from .create_keys import create_self_signed_cert
 from .version import xenon_grpc_version
 
@@ -53,15 +51,14 @@ def start_xenon_server(port=50051, disable_tls=False):
     cmd = ['java', '-jar', jar_file, '-p', str(port)]
 
     if not disable_tls:
-        create_self_signed_cert()
-        config_dir = Path(BaseDirectory.xdg_config_home) / 'xenon-grpc'
-        crt_file = config_dir / 'server.crt'
-        key_file = config_dir / 'server.key'
+        crt_file, key_file = create_self_signed_cert()
 
         cmd.extend([
             '--server-cert-chain', str(crt_file),
             '--server-private-key', str(key_file),
             '--client-cert-chain', str(crt_file)])
+    else:
+        crt_file = key_file = None
 
     process = subprocess.Popen(
         cmd,
@@ -69,4 +66,4 @@ def start_xenon_server(port=50051, disable_tls=False):
         universal_newlines=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
-    return process
+    return process, crt_file, key_file

--- a/xenon/create_keys.py
+++ b/xenon/create_keys.py
@@ -4,21 +4,24 @@ Certificate creation.
 
 import logging
 from socket import gethostname
-from pathlib import Path
 
-from xdg import BaseDirectory
 from OpenSSL import crypto
+
+from pathlib import Path
+from xdg import BaseDirectory
 
 
 def create_self_signed_cert():
     """Creates a self-signed certificate key pair."""
     config_dir = Path(BaseDirectory.xdg_config_home) / 'xenon-grpc'
     config_dir.mkdir(parents=True, exist_ok=True)
-    crt_file = config_dir / 'server.crt'
-    key_file = config_dir / 'server.key'
+
+    key_prefix = gethostname()
+    crt_file = config_dir / ('%s.crt' % key_prefix)
+    key_file = config_dir / ('%s.key' % key_prefix)
 
     if crt_file.exists() and key_file.exists():
-        return
+        return crt_file, key_file
 
     logger = logging.getLogger('xenon')
     logger.info("Creating authentication keys for xenon-grpc.")
@@ -42,3 +45,5 @@ def create_self_signed_cert():
         crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
     open(str(key_file), "wb").write(
         crypto.dump_privatekey(crypto.FILETYPE_PEM, k))
+
+    return crt_file, key_file

--- a/xenon/server.py
+++ b/xenon/server.py
@@ -72,7 +72,8 @@ class Server(object):
             logger.info('Xenon-GRPC servers seems to be running.')
         else:
             logger.info('Starting Xenon-GRPC server.')
-            self.process, crt_file, key_file = start_xenon_server(self.port, self.disable_tls)
+            self.process, crt_file, key_file = \
+                start_xenon_server(self.port, self.disable_tls)
 
             for name, output in [('out', self.process.stdout),
                                  ('err', self.process.stderr)]:


### PR DESCRIPTION
This prevents errors when systems have a shared filesystem.
Also create the name in a single place and pass around.